### PR TITLE
PagesCredentials.swift Xcode run friendly

### DIFF
--- a/Sources/KituraCredentialsSample/PagesCredentials.swift
+++ b/Sources/KituraCredentialsSample/PagesCredentials.swift
@@ -15,6 +15,7 @@
  **/
 
 
+import Foundation
 import Kitura
 import Credentials
 import CredentialsFacebook


### PR DESCRIPTION
I was getting this when trying to run from Xcode:

```
Undefined symbols for architecture x86_64:
  "(extension in Foundation):Swift.String._bridgeToObjectiveC () -> __ObjC.NSString", referenced from:
      KituraCredentialsSample.setupPages () -> () in PagesCredentials.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

And this was easily fixed by adding `import Foundation` to `PagesCredentials.swift` 👍
